### PR TITLE
Fix url for TypeScript site in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ How?
 
 With thanks to their authors.
 
-* [Typescript](http://http://www.typescriptlang.org/)
+* [Typescript](http://www.typescriptlang.org/)
 * [KnockoutJS](http://www.knockoutjs.com)
 * [jQuery](http://jquery.com)
 * [jQuery.hotkeys](https://github.com/jeresig/jquery.hotkeys/)


### PR DESCRIPTION
It's a relatively small thing, but I noticed the link for TypeScript's website wasn't formatted correctly in the README. Clicking on it took me to a browser error page (Google Chrome), so I looked at the code and corrected the problem.
